### PR TITLE
Add a exception for deleted aws secrets manager

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -149,7 +149,7 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 				}
 			}
 		}
-		catch (ResourceNotFoundException | IOException e) {
+		catch (ResourceNotFoundException | InvalidRequestException | IOException e) {
 			log.debug(String.format(
 					"Skip adding propertySource. Unable to load secrets from AWS Secrets Manager for secretId=%s",
 					path), e);


### PR DESCRIPTION
If aws client requests a secret group in `aws secrets manager` is waiting for a deletion, it returns 400 code with `InvalidRequestException`.

However, the code is only treating `ResourceNotFoundException` as known one.

<img width="1187" alt="Screen Shot 2022-07-23 at 13 31 18" src="https://user-images.githubusercontent.com/3631891/180590490-112d7338-3a33-4bd4-9ada-09aa28de7439.png">
<img width="1043" alt="Screen Shot 2022-07-23 at 13 34 49" src="https://user-images.githubusercontent.com/3631891/180590501-fe3046a1-49fe-4870-b5f2-ddf0691758aa.png">